### PR TITLE
Changed Deck test to use eql

### DIFF
--- a/test/Deck-test.js
+++ b/test/Deck-test.js
@@ -21,9 +21,7 @@ describe('Deck', function() {
     const card2 = new Card(2, 'What is a comma-separated list of related values?', ['array', 'object', 'function'], 'array');
     const card3 = new Card(3, 'What type of prototype method does not modify the existing array but returns a particular representation of the array?', ['mutator method', 'accessor method', 'iteration method'], 'mutator method');
     const deck = new Deck([card1, card2, card3]);
-    expect(deck.cards[0]).to.equal(card1);
-    expect(deck.cards[1]).to.equal(card2);
-    expect(deck.cards[2]).to.equal(card3);
+    expect(deck.cards).to.eql([card1, card2, card3])
   });
 
   it('should be able to return how many cards it has', function() {


### PR DESCRIPTION
After discovering chai's `eql` I went back and changed `Deck-test.js` to use it. I'll probably comb through and look for more places to use it tomorrow. 